### PR TITLE
Endpoints in different ports

### DIFF
--- a/server/dpow/config.py
+++ b/server/dpow/config.py
@@ -9,7 +9,6 @@ class DpowConfig(object):
         parser.add_argument('--blocks_port', type=int, default=5040, help="Web server port for incoming blocks via the node callback")
         parser.add_argument('--use_websocket', action='store_true', help="If enabled, will get blocks via websocket and not callback")
         parser.add_argument('--websocket_uri', type=str, default='ws://[::1]:7078', help="The Node (v19+) websocket server URI")
-        parser.add_argument('--callback_remote_ip', type=str, default='127.0.0.1', help="The IP from the node that is redirecting the callback to --web_host")
         parser.add_argument('--redis_uri', type=str, default='redis://localhost', help="Redis server URI")
         parser.add_argument('--mqtt_uri', type=str, default='mqtt://localhost:1883', help="MQTT broker URI")
         parser.add_argument('--debug', action='store_true', help="Enable debugging mode (all blocks are precached")
@@ -21,7 +20,6 @@ class DpowConfig(object):
         self.blocks_port = args.blocks_port
         self.use_websocket = args.use_websocket
         self.websocket_uri = args.websocket_uri
-        self.callback_remote_ip = args.callback_remote_ip
         self.redis_uri = args.redis_uri
         self.mqtt_uri = args.mqtt_uri
         self.debug = args.debug

--- a/server/dpow/config.py
+++ b/server/dpow/config.py
@@ -5,7 +5,8 @@ class DpowConfig(object):
     def __init__(self):
         parser = argparse.ArgumentParser()
         parser.add_argument('--web_host', type=str, default='127.0.0.1', help="Web server host")
-        parser.add_argument('--web_port', type=int, default=5030, help="Web server port")
+        parser.add_argument('--requests_port', type=int, default=5030, help="Web server port for incoming service requests")
+        parser.add_argument('--blocks_port', type=int, default=5040, help="Web server port for incoming blocks via the node callback")
         parser.add_argument('--use_websocket', action='store_true', help="If enabled, will get blocks via websocket and not callback")
         parser.add_argument('--websocket_uri', type=str, default='ws://[::1]:7078', help="The Node (v19+) websocket server URI")
         parser.add_argument('--callback_remote_ip', type=str, default='127.0.0.1', help="The IP from the node that is redirecting the callback to --web_host")
@@ -16,7 +17,8 @@ class DpowConfig(object):
         args = parser.parse_args()
 
         self.web_host = args.web_host
-        self.web_port = args.web_port
+        self.requests_port = args.requests_port
+        self.blocks_port = args.blocks_port
         self.use_websocket = args.use_websocket
         self.websocket_uri = args.websocket_uri
         self.callback_remote_ip = args.callback_remote_ip

--- a/server/dpow/mqtt.py
+++ b/server/dpow/mqtt.py
@@ -32,7 +32,10 @@ class DpowMQTT(object):
         ])
 
     async def close(self):
-        await self.connection.disconnect()
+        try:
+            await self.connection.disconnect()
+        except:
+            pass
 
     async def send(self, topic: str, message: str, qos=QOS_0):
         await self.connection.publish(topic, str.encode(message), qos=qos)


### PR DESCRIPTION
Obviously handling filtering at the firewall level is better, so now we have a port for the service requests endpoint, and another for the blocks callback.

Approach based on https://stackoverflow.com/a/46763016