### PR TITLE
Fix daily rollover breaking logging on Windows

### DIFF
--- a/client/logger.py
+++ b/client/logger.py
@@ -2,6 +2,16 @@ import sys
 import logging
 from logging.handlers import WatchedFileHandler, TimedRotatingFileHandler
 
+class WatchedTimedRotatingFileHandler(TimedRotatingFileHandler, WatchedFileHandler):
+    def __init__(self, filename, **kwargs):
+        super().__init__(filename, **kwargs)
+        self.dev, self.ino = -1, -1
+        self._statstream()
+
+    def emit(self, record):
+        self.reopenIfNeeded()
+        super().emit(record)
+
 def get_logger():
     log_file = "logs/dpow.txt"
     logger = logging.getLogger("dpow")
@@ -10,9 +20,8 @@ def get_logger():
     stream.setFormatter(logging.Formatter("%(asctime)s %(levelname)s: %(message)s", "%H:%M:%S"))
     stream.setLevel(logging.INFO)
     logger.addHandler(stream)
-    file = WatchedFileHandler(log_file)
-    file.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(filename)s@%(funcName)s:%(lineno)s", "%Y-%m-%d %H:%M:%S %z"))
+    file = WatchedTimedRotatingFileHandler(log_file, when="d", interval=1, backupCount=30)
+    file.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(filename)s@%(funcName)s:%(lineno)s\n%(message)s", "%Y-%m-%d %H:%M:%S %z"))
     file.setLevel(logging.DEBUG)
     logger.addHandler(file)
-    logger.addHandler(TimedRotatingFileHandler(log_file, when="d", interval=1, backupCount=30))
     return logger


### PR DESCRIPTION
To quickly test rollover, set `when="m"` to use per-minute rotation instead of daily.
Works as expected on Windows, not tested on GNU/Linux.

> WatchedFileHandler is not appropriate for use under Windows, because under Windows open log files cannot be moved or renamed - logging opens the files with exclusive locks - and so there is no need for such a handler. Furthermore, ST_INO is not supported under Windows; stat() always returns zero for this value.