### PR TITLE
Use a forked hbmqtt library with support for python3.9

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,3 +1,4 @@
-hbmqtt
 aiohttp
 requests
+# hbmqtt # disabled until python3.9 is supported, alternative below
+git+git://github.com/Yakifo/aio-hbmqtt@4a9594e


### PR DESCRIPTION
This will not be merged until the forked library has a proper release.

If you run into the issue, simply checkout to the `python3.9-client-fix` branch and re-install the dependencies with `pip3 install --upgrade -r requirements.txt`, should work.